### PR TITLE
Request `contentType` handlers

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ var sources = [
     "./src/RequestSugar.js",
     "./src/RequestUrlHelpers.js",
     "./src/MethodShorthands.js",
+    "./src/RequestTypeHandlers/*.js",
     "./src/ResponseTypeHandlers/*.js"
 ];
 

--- a/src/RequestSugar.js
+++ b/src/RequestSugar.js
@@ -4,19 +4,31 @@ Http.Request = function (Delegate) {
     var defaultOptions = {
         method: "GET",
         crossOrigin: "anonymous",
-        responseType: "json"
+        responseType: "json",
+        contentType: "form-urlencoded"
     };
 
     var responseTypeHandlers = {};
+    var requestTypeHandlers = {};
 
 
     var prepareBody = function (options) {
+        if ( options.method !== "GET" && typeof requestTypeHandlers[options.contentType].formatBody === "function" ) {
+            options.body = requestTypeHandlers[options.contentType].formatBody.call(null, options.body);
+        }
+
         options.body = options.body || null;
     };
 
     var prepareDefaultHeaders = function (options) {
-        options.headers = _.extend({}, options.headers);
-        options.headers.Accept = responseTypeHandlers[options.responseType].mimetype;
+        var headers = {};
+        headers.Accept = responseTypeHandlers[options.responseType].mimetype;
+
+        if ( options.method !== "GET" ) {
+            headers["Content-Type"] = requestTypeHandlers[options.contentType].mimetype;
+        }
+
+        options.headers = _.extend(headers, options.headers);
     };
 
     var prepareOptions = function (options) {
@@ -122,6 +134,10 @@ Http.Request = function (Delegate) {
 
     HttpRequest.addResponseTypeHandler = function (name, handler) {
         responseTypeHandlers[name] = handler;
+    };
+
+    HttpRequest.addRequestTypeHandler = function (name, handler) {
+        requestTypeHandlers[name] = handler;
     };
 
     return HttpRequest;

--- a/src/RequestTypeHandlers/formUrlEncoded.js
+++ b/src/RequestTypeHandlers/formUrlEncoded.js
@@ -1,0 +1,8 @@
+Http.Request.addRequestTypeHandler("form-urlencoded", {
+    mimetype: "application/x-www-form-urlencoded",
+    formatBody: function (body) {
+        "use strict";
+
+        return URI.buildQuery(body).replace(/%20/g, "+");
+    }
+});

--- a/src/RequestTypeHandlers/json.js
+++ b/src/RequestTypeHandlers/json.js
@@ -1,0 +1,8 @@
+Http.Request.addRequestTypeHandler("json", {
+    mimetype: "application/json",
+    formatBody: function (body) {
+        "use strict";
+
+        return JSON.stringify(body);
+    }
+});

--- a/src/RequestTypeHandlers/text.js
+++ b/src/RequestTypeHandlers/text.js
@@ -1,0 +1,3 @@
+Http.Request.addRequestTypeHandler("text", {
+    mimetype: "text/plain"
+});

--- a/test/RequestSpec.js
+++ b/test/RequestSpec.js
@@ -43,7 +43,7 @@ describe("Http.Request", function () {
 
     it("should use the specified body", function () {
         server.respondWith("POST", "/", function (xhr) {
-            xhr.requestBody.should.equal("foo");
+            xhr.requestBody.should.equal("foo=bar");
             xhr.respond(200, {
                 "Content-Type": "application/json"
             }, defaultResponse);
@@ -52,7 +52,7 @@ describe("Http.Request", function () {
         var request = new Request({
             url: "/",
             method: "POST",
-            body: "foo"
+            body: { foo: "bar" }
         });
 
         return assertOk(request);

--- a/test/RequestTypeHandlers/formUrlEncodedSpec.js
+++ b/test/RequestTypeHandlers/formUrlEncodedSpec.js
@@ -1,0 +1,38 @@
+describe("Http Request with `contentType` set to `form-urlencoded`", function () {
+    "use strict";
+
+    var server;
+
+    beforeEach(function () {
+        server = sinon.fakeServer.create();
+        server.autoRespond = true;
+    });
+
+    afterEach(function () {
+        server.restore();
+    });
+
+    it("should URL encode the body", function () {
+        server.respondWith("POST", "/foo", function (xhr) {
+            xhr.requestBody.should.equal("foo=1&foo=2&bar=3+4");
+            xhr.respond(200, {
+                "Content-Type": "application/json"
+            }, "{\"ok\":true}");
+        });
+
+        var request = new Http.Request({
+            method: "POST",
+            url: "/foo",
+            body: {
+                foo: [1, 2],
+                bar: "3 4"
+            }
+        });
+
+        return request.send().then(function (result) {
+            result.statusCode.should.equal(200);
+            result.body.should.deep.equal({ ok: true });
+            result.headers["Content-Type"].should.equal("application/json");
+        });
+    });
+});

--- a/test/RequestTypeHandlers/jsonSpec.js
+++ b/test/RequestTypeHandlers/jsonSpec.js
@@ -1,0 +1,39 @@
+describe("Http Request with `contentType` set to `json`", function () {
+    "use strict";
+
+    var server;
+
+    beforeEach(function () {
+        server = sinon.fakeServer.create();
+        server.autoRespond = true;
+    });
+
+    afterEach(function () {
+        server.restore();
+    });
+
+    it("should JSON encode the body", function () {
+        server.respondWith("POST", "/foo", function (xhr) {
+            xhr.requestBody.should.equal("{\"foo\":[1,2],\"bar\":\"3 4\"}");
+            xhr.respond(200, {
+                "Content-Type": "application/json"
+            }, "{\"ok\":true}");
+        });
+
+        var request = new Http.Request({
+            method: "POST",
+            url: "/foo",
+            contentType: "json",
+            body: {
+                foo: [1, 2],
+                bar: "3 4"
+            }
+        });
+
+        return request.send().then(function (result) {
+            result.statusCode.should.equal(200);
+            result.body.should.deep.equal({ ok: true });
+            result.headers["Content-Type"].should.equal("application/json");
+        });
+    });
+});

--- a/test/RequestTypeHandlers/textSpec.js
+++ b/test/RequestTypeHandlers/textSpec.js
@@ -1,0 +1,36 @@
+describe("Http Request with `contentType` set to `text`", function () {
+    "use strict";
+
+    var server;
+
+    beforeEach(function () {
+        server = sinon.fakeServer.create();
+        server.autoRespond = true;
+    });
+
+    afterEach(function () {
+        server.restore();
+    });
+
+    it("should not encode the body", function () {
+        server.respondWith("POST", "/foo", function (xhr) {
+            xhr.requestBody.should.equal("foo");
+            xhr.respond(200, {
+                "Content-Type": "application/json"
+            }, "{\"ok\":true}");
+        });
+
+        var request = new Http.Request({
+            method: "POST",
+            url: "/foo",
+            contentType: "text",
+            body: "foo"
+        });
+
+        return request.send().then(function (result) {
+            result.statusCode.should.equal(200);
+            result.body.should.deep.equal({ ok: true });
+            result.headers["Content-Type"].should.equal("application/json");
+        });
+    });
+});


### PR DESCRIPTION
- Adds `contentType` handlers for `json`, `text`, `form-urlencoded`
- Makes `form-urlencoded` the default.
