### PR TITLE
Updates for IE9 compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Http.get({ url: "/foo" }).then(function (response) {
     //   }
     // }
     console.log(response);
-}).catch(function (error) {
+})["catch"](function (error) {
     // See section titled `Errors` for further information.
     console.error(error);
 });

--- a/config/karma/karma.conf.js
+++ b/config/karma/karma.conf.js
@@ -47,6 +47,14 @@ module.exports = function (config) {
                 os_version: "Mavericks"
             },
 
+            bs_ie_9: {
+                base: "BrowserStack",
+                browser: "ie",
+                browser_version: "9.0",
+                os: "Windows",
+                os_version: "7"
+            },
+
             bs_ie_10: {
                 base: "BrowserStack",
                 browser: "ie",
@@ -68,6 +76,7 @@ module.exports = function (config) {
             "bs_firefox_mac",
             "bs_opera_mac",
             "bs_chrome_mac",
+            "bs_ie_9",
             "bs_ie_10",
             "bs_ie_11"
         ] : ["PhantomJS"]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ var karma = require("gulp-karma");
 var concat = require("gulp-concat");
 
 var vendorJavascripts = [
-    "./bower_components/lodash/dist/lodash.js",
+    "./bower_components/lodash/dist/lodash.compat.js",
     "./bower_components/es6-promise/promise.js",
     "./bower_components/uri.js/src/URI.js"
 ];

--- a/test/HttpSpec.js
+++ b/test/HttpSpec.js
@@ -2,6 +2,6 @@ describe("Http", function () {
     "use strict";
 
     it("should be defined", function () {
-        Http.should.be.defined;
+        expect(Http).to.be.defined;
     });
 });

--- a/test/MethodShorthandsSpec.js
+++ b/test/MethodShorthandsSpec.js
@@ -19,9 +19,9 @@ describe("Http method shorthands", function () {
             }, "{\"ok\":true}"]);
 
             return Http[shorthand]({ url: "/foo" }).then(function (result) {
-                result.statusCode.should.equal(200);
-                result.body.should.deep.equal({ ok: true });
-                result.headers["Content-Type"].should.equal("application/json");
+                expect(result.statusCode).to.equal(200);
+                expect(result.body).to.deep.equal({ ok: true });
+                expect(result.headers["Content-Type"]).to.equal("application/json");
             });
         });
     });

--- a/test/RequestSpec.js
+++ b/test/RequestSpec.js
@@ -5,7 +5,7 @@ describe("Http.Request", function () {
     var server;
 
     it("should be a function", function () {
-        Request.should.be.a("function");
+        expect(Request).to.be.a("function");
     });
 
     beforeEach(function () {
@@ -21,9 +21,9 @@ describe("Http.Request", function () {
 
     var assertOk = function (request) {
         return request.send().then(function (result) {
-            result.statusCode.should.equal(200);
-            result.headers["Content-Type"].should.equal("application/json");
-            result.body.should.deep.equal({
+            expect(result.statusCode).to.equal(200);
+            expect(result.headers["Content-Type"]).to.equal("application/json");
+            expect(result.body).to.deep.equal({
                 foo: "bar"
             });
         });
@@ -43,7 +43,7 @@ describe("Http.Request", function () {
 
     it("should use the specified body", function () {
         server.respondWith("POST", "/", function (xhr) {
-            xhr.requestBody.should.equal("foo=bar");
+            expect(xhr.requestBody).to.equal("foo=bar");
             xhr.respond(200, {
                 "Content-Type": "application/json"
             }, defaultResponse);
@@ -77,7 +77,7 @@ describe("Http.Request", function () {
 
     it("should send the request with given headers", function () {
         server.respondWith("POST", "/", function (xhr) {
-            xhr.requestHeaders["X-Other-Custom"].should.equal("bar");
+            expect(xhr.requestHeaders["X-Other-Custom"]).to.equal("bar");
             xhr.respond(200, {
                 "Content-Type": "application/json"
             }, defaultResponse);
@@ -96,7 +96,7 @@ describe("Http.Request", function () {
 
     it("should not overwrite the Content-Type header", function () {
         server.respondWith("POST", "/", function (xhr) {
-            xhr.requestHeaders["Content-Type"].should.equal("foo;charset=utf-8");
+            expect(xhr.requestHeaders["Content-Type"]).to.equal("foo;charset=utf-8");
             xhr.respond(200, {
                 "Content-Type": "application/json"
             }, defaultResponse);
@@ -131,14 +131,14 @@ describe("Http.Request", function () {
 
             return request.send().then(function () {
                 throw new Error("request should have failed");
-            }).catch(function (error) {
-                error.should.be.an.instanceOf(Http.Errors.HttpError);
-                error.statusCode.should.equal(statusCode);
-                error.headers["X-Custom"].should.equal("foo");
-                error.body.should.deep.equal({
+            })["catch"](function (error) {
+                expect(error).to.be.an.instanceOf(Http.Errors.HttpError);
+                expect(error.statusCode).to.equal(statusCode);
+                expect(error.headers["X-Custom"]).to.equal("foo");
+                expect(error.body).to.deep.equal({
                     message: "meow"
                 });
-                error.message.should.equal("POST \"/\" failed with status " + statusCode);
+                expect(error.message).to.equal("POST \"/\" failed with status " + statusCode);
             });
         });
     });
@@ -158,15 +158,15 @@ describe("Http.Request", function () {
 
         return request.send().then(function () {
             throw new Error("request should have failed");
-        }).catch(function (error) {
-            error.should.be.an.instanceOf(Http.Errors.NetworkError);
-            error.message.should.equal("POST \"/\" failed due to a network error (missing CORS headers?)");
+        })["catch"](function (error) {
+            expect(error).to.be.an.instanceOf(Http.Errors.NetworkError);
+            expect(error.message).to.equal("POST \"/\" failed due to a network error (missing CORS headers?)");
         });
     });
 
     it("should send the request with credentials, if `crossOrigin` attribute is set to `use-credentials`", function () {
         server.respondWith("GET", "http://otherdomain.com/foo", function (xhr) {
-            xhr.withCredentials.should.equal(true);
+            expect(xhr.withCredentials).to.equal(true);
             xhr.respond(200, {
                 "Content-Type": "application/json"
             }, defaultResponse);
@@ -182,7 +182,7 @@ describe("Http.Request", function () {
 
     it("should default to not sending the request with credentials", function () {
         server.respondWith("GET", "http://otherdomain.com/foo", function (xhr) {
-            xhr.withCredentials.should.equal(false);
+            expect(xhr.withCredentials).to.equal(false);
             xhr.respond(200, {
                 "Content-Type": "application/json"
             }, defaultResponse);
@@ -197,7 +197,7 @@ describe("Http.Request", function () {
 
     describe(".createXhr()", function () {
         it("should create a new XMLHttpRequest", function () {
-            Request.createXhr().should.be.an.instanceOf(XMLHttpRequest);
+            expect(Request.createXhr()).to.be.an.instanceOf(XMLHttpRequest);
         });
     });
 });

--- a/test/RequestTypeHandlers/formUrlEncodedSpec.js
+++ b/test/RequestTypeHandlers/formUrlEncodedSpec.js
@@ -14,7 +14,7 @@ describe("Http Request with `contentType` set to `form-urlencoded`", function ()
 
     it("should URL encode the body", function () {
         server.respondWith("POST", "/foo", function (xhr) {
-            xhr.requestBody.should.equal("foo=1&foo=2&bar=3+4");
+            expect(xhr.requestBody).to.equal("foo=1&foo=2&bar=3+4");
             xhr.respond(200, {
                 "Content-Type": "application/json"
             }, "{\"ok\":true}");
@@ -30,9 +30,9 @@ describe("Http Request with `contentType` set to `form-urlencoded`", function ()
         });
 
         return request.send().then(function (result) {
-            result.statusCode.should.equal(200);
-            result.body.should.deep.equal({ ok: true });
-            result.headers["Content-Type"].should.equal("application/json");
+            expect(result.statusCode).to.equal(200);
+            expect(result.body).to.deep.equal({ ok: true });
+            expect(result.headers["Content-Type"]).to.equal("application/json");
         });
     });
 });

--- a/test/RequestTypeHandlers/jsonSpec.js
+++ b/test/RequestTypeHandlers/jsonSpec.js
@@ -14,7 +14,7 @@ describe("Http Request with `contentType` set to `json`", function () {
 
     it("should JSON encode the body", function () {
         server.respondWith("POST", "/foo", function (xhr) {
-            xhr.requestBody.should.equal("{\"foo\":[1,2],\"bar\":\"3 4\"}");
+            expect(xhr.requestBody).to.equal("{\"foo\":[1,2],\"bar\":\"3 4\"}");
             xhr.respond(200, {
                 "Content-Type": "application/json"
             }, "{\"ok\":true}");
@@ -31,9 +31,9 @@ describe("Http Request with `contentType` set to `json`", function () {
         });
 
         return request.send().then(function (result) {
-            result.statusCode.should.equal(200);
-            result.body.should.deep.equal({ ok: true });
-            result.headers["Content-Type"].should.equal("application/json");
+            expect(result.statusCode).to.equal(200);
+            expect(result.body).to.deep.equal({ ok: true });
+            expect(result.headers["Content-Type"]).to.equal("application/json");
         });
     });
 });

--- a/test/RequestTypeHandlers/textSpec.js
+++ b/test/RequestTypeHandlers/textSpec.js
@@ -14,7 +14,7 @@ describe("Http Request with `contentType` set to `text`", function () {
 
     it("should not encode the body", function () {
         server.respondWith("POST", "/foo", function (xhr) {
-            xhr.requestBody.should.equal("foo");
+            expect(xhr.requestBody).to.equal("foo");
             xhr.respond(200, {
                 "Content-Type": "application/json"
             }, "{\"ok\":true}");
@@ -28,9 +28,9 @@ describe("Http Request with `contentType` set to `text`", function () {
         });
 
         return request.send().then(function (result) {
-            result.statusCode.should.equal(200);
-            result.body.should.deep.equal({ ok: true });
-            result.headers["Content-Type"].should.equal("application/json");
+            expect(result.statusCode).to.equal(200);
+            expect(result.body).to.deep.equal({ ok: true });
+            expect(result.headers["Content-Type"]).to.equal("application/json");
         });
     });
 });

--- a/test/RequestUrlHelpersSpec.js
+++ b/test/RequestUrlHelpersSpec.js
@@ -21,9 +21,9 @@ describe("Http Request URL Helpers", function () {
             var request = new Http.Request(parameters);
 
             return request.send().then(function (result) {
-                result.statusCode.should.equal(200);
-                result.body.should.deep.equal({ ok: true });
-                result.headers["Content-Type"].should.equal("application/json");
+                expect(result.statusCode).to.equal(200);
+                expect(result.body).to.deep.equal({ ok: true });
+                expect(result.headers["Content-Type"]).to.equal("application/json");
             });
         };
     };

--- a/test/ResponseTypeHandlers/jsonSpec.js
+++ b/test/ResponseTypeHandlers/jsonSpec.js
@@ -16,7 +16,7 @@ describe("Http.Request (json response type handler)", function () {
 
     it("should send the request to the given URL", function () {
         server.respondWith("GET", "http://otherdomain.com/foo", function (xhr) {
-            xhr.requestHeaders.Accept.should.equal("application/json");
+            expect(xhr.requestHeaders.Accept).to.equal("application/json");
             xhr.respond(200, {
                 "Content-Type": "application/json"
             }, defaultResponse);
@@ -26,9 +26,9 @@ describe("Http.Request (json response type handler)", function () {
             url: "http://otherdomain.com/foo",
             responseType: "json"
         }).then(function (result) {
-            result.statusCode.should.equal(200);
-            result.headers["Content-Type"].should.equal("application/json");
-            result.body.should.deep.equal({
+            expect(result.statusCode).to.equal(200);
+            expect(result.headers["Content-Type"]).to.equal("application/json");
+            expect(result.body).to.deep.equal({
                 foo: "bar"
             });
         });
@@ -36,7 +36,7 @@ describe("Http.Request (json response type handler)", function () {
 
     it("should throw an error if response is not valid JSON", function () {
         server.respondWith("GET", "http://otherdomain.com/foo", function (xhr) {
-            xhr.requestHeaders.Accept.should.equal("application/json");
+            expect(xhr.requestHeaders.Accept).to.equal("application/json");
             xhr.respond(200, {
                 "Content-Type": "application/json"
             }, "{foo:1}");
@@ -47,12 +47,12 @@ describe("Http.Request (json response type handler)", function () {
             responseType: "json"
         }).then(function () {
             throw new Error("request should have failed");
-        }).catch(function (error) {
-            error.should.be.an.instanceOf(Http.Errors.ResponseError);
-            error.statusCode.should.equal(200);
-            error.headers["Content-Type"].should.equal("application/json");
-            error.body.should.equal("{foo:1}");
-            error.message.should.equal("GET \"http://otherdomain.com/foo\" failed: response is not of type json");
+        })["catch"](function (error) {
+            expect(error).to.be.an.instanceOf(Http.Errors.ResponseError);
+            expect(error.statusCode).to.equal(200);
+            expect(error.headers["Content-Type"]).to.equal("application/json");
+            expect(error.body).to.equal("{foo:1}");
+            expect(error.message).to.equal("GET \"http://otherdomain.com/foo\" failed: response is not of type json");
         });
     });
 });

--- a/test/ResponseTypeHandlers/textSpec.js
+++ b/test/ResponseTypeHandlers/textSpec.js
@@ -14,7 +14,7 @@ describe("Http.Request (text response type handler)", function () {
 
     it("should send the request to the given URL", function () {
         server.respondWith("GET", "/foo", function (xhr) {
-            xhr.requestHeaders.Accept.should.equal("text/plain");
+            expect(xhr.requestHeaders.Accept).to.equal("text/plain");
             xhr.respond(200, {
                 "Content-Type": "text/plain"
             }, "Ok");
@@ -24,9 +24,9 @@ describe("Http.Request (text response type handler)", function () {
             url: "/foo",
             responseType: "text"
         }).then(function (result) {
-            result.statusCode.should.equal(200);
-            result.headers["Content-Type"].should.equal("text/plain");
-            result.body.should.equal("Ok");
+            expect(result.statusCode).to.equal(200);
+            expect(result.headers["Content-Type"]).to.equal("text/plain");
+            expect(result.body).to.equal("Ok");
         });
     });
 });

--- a/test/ResponseTypeHandlers/xmlSpec.js
+++ b/test/ResponseTypeHandlers/xmlSpec.js
@@ -16,7 +16,7 @@ describe("Http.Request (xml response type handler)", function () {
 
     it("should send the request to the given URL", function () {
         server.respondWith("GET", "/foo", function (xhr) {
-            xhr.requestHeaders.Accept.should.equal("application/xml, text/xml");
+            expect(xhr.requestHeaders.Accept).to.equal("application/xml, text/xml");
             xhr.respond(200, {
                 "Content-Type": "application/xml"
             }, defaultResponse);
@@ -26,16 +26,16 @@ describe("Http.Request (xml response type handler)", function () {
             url: "/foo",
             responseType: "xml"
         }).then(function (result) {
-            result.statusCode.should.equal(200);
-            result.headers["Content-Type"].should.equal("application/xml");
-            result.body.documentElement.nodeName.should.equal("foo");
-            result.body.documentElement.textContent.should.equal("bar");
+            expect(result.statusCode).to.equal(200);
+            expect(result.headers["Content-Type"]).to.equal("application/xml");
+            expect(result.body.documentElement.nodeName).to.equal("foo");
+            expect(result.body.documentElement.textContent).to.equal("bar");
         });
     });
 
     it("should throw an error if response is not valid XML", function () {
         server.respondWith("GET", "/foo", function (xhr) {
-            xhr.requestHeaders.Accept.should.equal("application/xml, text/xml");
+            expect(xhr.requestHeaders.Accept).to.equal("application/xml, text/xml");
             xhr.respond(200, {
                 "Content-Type": "text/xml"
             }, "<error");
@@ -47,12 +47,12 @@ describe("Http.Request (xml response type handler)", function () {
             responseType: "xml"
         }).then(function (result) {
             throw new Error("request should have failed");
-        }).catch(function (error) {
-            error.should.be.an.instanceOf(Http.Errors.ResponseError);
-            error.statusCode.should.equal(200);
-            error.headers["Content-Type"].should.equal("text/xml");
-            error.body.should.equal("<error");
-            error.message.should.equal("GET \"/foo\" failed: response is not of type xml");
+        })["catch"](function (error) {
+            expect(error).to.be.an.instanceOf(Http.Errors.ResponseError);
+            expect(error.statusCode).to.equal(200);
+            expect(error.headers["Content-Type"]).to.equal("text/xml");
+            expect(error.body).to.equal("<error");
+            expect(error.message).to.equal("GET \"/foo\" failed: response is not of type xml");
         });
     });
 });


### PR DESCRIPTION
- Updated test suite to use expect instead of should.
- Use ["catch"] instead of .catch for ES3 compatibility.
